### PR TITLE
Restoring logger compatibility upon logger being set to nil

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -209,7 +209,7 @@ module Sidekiq
 
   def self.logger=(logger)
     if logger.nil?
-      self.logger.fatal!
+      self.logger.level = Logger::FATAL
       return self.logger
     end
 


### PR DESCRIPTION
As part of Sidekiq v.4.6.2, the way the log level is set when Sidekiq's logger is explicitly set to `nil` broke compatibility with gems like RailsSemanticLogger.

Problematic case:

If a Rails app uses RailsSemanticLogger and sets `Sidekiq.logger = nil` in an initializer the app would not be able to load due to an undefined method error. This was caused by the fact that

* RailsSemanticLogger sets Sidekiq's logger to a SemanticLogger instance
* Setting Sidekiq's logger later on would trigger a call to logger.fatal!

SemanticLogger does not implement `fatal!` and this would be the cause of the error.

This PR fixes the isssue by reverting the way the log level is set.

(fixes #5297)